### PR TITLE
support Env

### DIFF
--- a/page.go
+++ b/page.go
@@ -4,12 +4,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 )
 
-var remote string = "http://raw.github.com/rprieto/tldr/master/pages"
+var defaultRemote string = "http://raw.github.com/rprieto/tldr/master/pages"
 
 // Caller must close the response body after reading.
 func GetPageForPlatform(page, platform string) (io.ReadCloser, error) {
+	remote := defaultRemote
+	if env := os.Getenv("TLDRREMOTE"); env != "" {
+		remote = env
+	}
 	resp, err := http.Get(remote + "/" + platform + "/" + page + ".md")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When we fork the repo https://github.com/tldr-pages/tldr and contribute some pages， we can not use them until you accept the pr.if `tldr` support `TLDRREMOTE ` environment value,we can use it temporarily