### PR TITLE
Fix #13 'Unexpected status code: 404' error

### DIFF
--- a/lib/tldr/remote/repository.go
+++ b/lib/tldr/remote/repository.go
@@ -37,7 +37,7 @@ func (f *Repository) Page(page, platform string) (entity.Page, error) {
 }
 
 func (f *Repository) Index() (entity.Index, error) {
-	resp, err := http.Get(f.remote + "/index.json")
+	resp, err := http.Get("https://tldr-pages.github.io/assets/index.json")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
According to a `.gitignore` file from `tldr-pages` repo file `index.json` was moved from the repo to a `https://tldr-pages.github.io/assets/index.json` so I fixed it and now it works.